### PR TITLE
Minor fix to curriculum affiliation migration

### DIFF
--- a/app/models/completed_learning_unit.rb
+++ b/app/models/completed_learning_unit.rb
@@ -1,4 +1,4 @@
 class CompletedLearningUnit < ApplicationRecord
-  belongs_to :users
-  belongs_to :learning_units
+  belongs_to :user
+  belongs_to :learning_unit
 end

--- a/db/migrate/20220823014548_add_curriculum_affiliation_relationships.rb
+++ b/db/migrate/20220823014548_add_curriculum_affiliation_relationships.rb
@@ -2,7 +2,6 @@ class AddCurriculumAffiliationRelationships < ActiveRecord::Migration[7.0]
   def change
     add_column :curriculum_affiliations, :curriculum_id, :integer
     add_column :curriculum_affiliations, :learning_unit_id, :integer
-    add_column :curriculums, :curriculum_affiliation_id, :integer
-    add_column :learning_units, :curriculum_affiliation_id, :integer
   end
 end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,14 +33,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_23_124350) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "curriculum_affiliation_id"
   end
 
   create_table "learning_units", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "curriculum_affiliation_id"
   end
 
   create_table "resource_comments", force: :cascade do |t|


### PR DESCRIPTION
By mistake I added curriculum_affiliation_id's to both curriculum and learning_unit models. This commit fixes that.