### PR TITLE
Revert "Fix schema: remove redundant columns "

### DIFF
--- a/db/migrate/20220830132133_remove_curriculum_affiliation_id_from_curriculums.rb
+++ b/db/migrate/20220830132133_remove_curriculum_affiliation_id_from_curriculums.rb
@@ -1,5 +1,0 @@
-class RemoveCurriculumAffiliationIdFromCurriculums < ActiveRecord::Migration[7.0]
-  def change
-    remove_column :curriculums, :curriculum_affiliation_id, :integer
-  end
-end

--- a/db/migrate/20220830132312_remove_curriculum_affiliation_id_from_learning_units.rb
+++ b/db/migrate/20220830132312_remove_curriculum_affiliation_id_from_learning_units.rb
@@ -1,5 +1,0 @@
-class RemoveCurriculumAffiliationIdFromLearningUnits < ActiveRecord::Migration[7.0]
-  def change
-    remove_column :learning_units, :curriculum_affiliation_id, :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_30_132312) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_30_000054) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -59,12 +59,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_30_132312) do
     t.string 'name'
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
+    t.integer 'curriculum_affiliation_id'
   end
 
   create_table 'learning_units', force: :cascade do |t|
     t.string 'name'
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
+    t.integer 'curriculum_affiliation_id'
   end
 
   create_table 'resource_comments', force: :cascade do |t|


### PR DESCRIPTION
Reverts rtichauerv/paraffin#21
We had an issue with an old migration which created a mistake in the schema.
We'll need to reset our local databases to run these new migrations.