### PR TITLE
fix(model/curriculum_affiliation): require validation, create factories and test factories

### DIFF
--- a/app/models/curriculum_affiliation.rb
+++ b/app/models/curriculum_affiliation.rb
@@ -1,4 +1,7 @@
 class CurriculumAffiliation < ApplicationRecord
   belongs_to :curriculum
   belongs_to :learning_unit
+
+  validates :curriculum, presence: true
+  validates :learning_unit, presence: true
 end

--- a/spec/factories/curriculum.rb
+++ b/spec/factories/curriculum.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :curriculum do
+    name { 'Fin program' }
+  end
+end

--- a/spec/factories/curriculum_affiliation.rb
+++ b/spec/factories/curriculum_affiliation.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :curriculum_affiliation do
+    association :curriculum, factory: :curriculum
+    association :learning_unit, factory: :learning_unit
+  end
+end

--- a/spec/models/curriculum_affiliation_spec.rb
+++ b/spec/models/curriculum_affiliation_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe CurriculumAffiliation, type: :model do
+  context 'when creating an object with the factory' do
+    it do
+      expect(build(:curriculum_affiliation)).to be_valid
+    end
+  end
+
   it 'is valid with valid attributes'
   it 'is not valid without a curriculum_id'
   it 'is not valid without a learning_unit_id'

--- a/spec/models/curriculum_spec.rb
+++ b/spec/models/curriculum_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Curriculum, type: :model do
+  context 'when creating an object with the factory' do
+    it do
+      expect(build(:curriculum)).to be_valid
+    end
+  end
+
   it 'is not valid without a name' do
     curriculum = described_class.new(name: nil)
     expect(curriculum).not_to be_valid

--- a/spec/models/currifulum_affiliation_spec.rb
+++ b/spec/models/currifulum_affiliation_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CurriculumAffiliation, type: :model do
+  it 'is valid with valid attributes'
+  it 'is not valid without a curriculum_id'
+  it 'is not valid without a learning_unit_id'
+end


### PR DESCRIPTION
In CurriculumAffiliation model, validates presence of curriculum_id and learning_unit_id.
Create curriculum_affiliation_spec and name tests (pending for implementation).
Create factories for models Curriculum and CurriculumAffiliation.
Implements tests for those factories.