### PR TITLE
test: add a method to create a curriculum with learning units and use it to test the learning units index view

### DIFF
--- a/spec/factories/curriculum.rb
+++ b/spec/factories/curriculum.rb
@@ -3,3 +3,9 @@ FactoryBot.define do
     name { 'Fin program' }
   end
 end
+
+def curriculum_with_learning_units(learning_units_count: 5)
+  FactoryBot.create(:curriculum) do |curriculum|
+    FactoryBot.create_list(:learning_unit, learning_units_count, curriculums: [curriculum])
+  end
+end

--- a/spec/requests/learning_units_controller_spec.rb
+++ b/spec/requests/learning_units_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+
 RSpec.describe LearningUnitsController, type: :request do
   describe 'GET /show' do
     let(:user) { create(:user) }
@@ -21,7 +22,7 @@ RSpec.describe LearningUnitsController, type: :request do
 
   describe 'GET /index' do
     let(:user) { create(:user) }
-    let(:curriculum) { create(:curriculum) }
+    let(:curriculum) { curriculum_with_learning_units(learning_units_count: 7) }
     let(:params) do
       { 'curriculum_id': curriculum.id }
     end
@@ -37,7 +38,12 @@ RSpec.describe LearningUnitsController, type: :request do
 
     it 'shows the name of the curriculum' do
       perform
-      expect(response.body).to include(curriculum.name)
+      expect(response.body).to match(curriculum.name)
+    end
+
+    it 'shows the name of the learning units' do
+      perform
+      expect(response.body).to match(curriculum.learning_units.first.name)
     end
   end
 end

--- a/spec/requests/learning_units_controller_spec.rb
+++ b/spec/requests/learning_units_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+RSpec.describe LearningUnitsController, type: :request do
+  describe 'GET /show' do
+    let(:user) { create(:user) }
+    let(:learning_unit) { create(:learning_unit) }
+
+    before do
+      sign_in user
+    end
+
+    context 'when accesing to the learning unit page'
+    def perform
+      get learning_unit_path(learning_unit)
+    end
+
+    it 'shows the name of the learning unit' do
+      perform
+      expect(response.body).to include(learning_unit.name)
+    end
+  end
+
+  describe 'GET /index' do
+    let(:user) { create(:user) }
+    let(:curriculum) { create(:curriculum) }
+    let(:params) do
+      { 'curriculum_id': curriculum.id }
+    end
+
+    before do
+      sign_in user
+    end
+
+    context 'when accesing the curriculum page'
+    def perform
+      get curriculum_learning_units_path(params)
+    end
+
+    it 'shows the name of the curriculum' do
+      perform
+      expect(response.body).to include(curriculum.name)
+    end
+  end
+end

--- a/spec/requests/learning_units_controller_spec.rb
+++ b/spec/requests/learning_units_controller_spec.rb
@@ -9,14 +9,15 @@ RSpec.describe LearningUnitsController, type: :request do
       sign_in user
     end
 
-    context 'when accesing to the learning unit page'
-    def perform
-      get learning_unit_path(learning_unit)
-    end
+    context 'when accesing to the learning unit page' do
+      def perform
+        get learning_unit_path(learning_unit)
+      end
 
-    it 'shows the name of the learning unit' do
-      perform
-      expect(response.body).to include(learning_unit.name)
+      it 'shows the name of the learning unit' do
+        perform
+        expect(response.body).to include(learning_unit.name)
+      end
     end
   end
 
@@ -31,19 +32,20 @@ RSpec.describe LearningUnitsController, type: :request do
       sign_in user
     end
 
-    context 'when accesing the curriculum page'
-    def perform
-      get curriculum_learning_units_path(params)
-    end
+    context 'when accesing the curriculum page' do
+      def perform
+        get curriculum_learning_units_path(params)
+      end
 
-    it 'shows the name of the curriculum' do
-      perform
-      expect(response.body).to match(curriculum.name)
-    end
+      it 'shows the name of the curriculum' do
+        perform
+        expect(response.body).to match(curriculum.name)
+      end
 
-    it 'shows the name of the learning units' do
-      perform
-      expect(response.body).to match(curriculum.learning_units.first.name)
+      it 'shows the name of the learning units' do
+        perform
+        expect(response.body).to match(curriculum.learning_units.first.name)
+      end
     end
   end
 end


### PR DESCRIPTION
Using the official documentation of factory_bot https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#has_many-associations
I implemented the method curriculum_with_learning_units. This method creates a curriculum and adds learning units to it. Those learning units needs to reference the curriculum.

The method  curriculum_with_learning_units is used to test the index view of learning_units.  This view receives a curriculum, renders the name of the curriculum and the corresponding learning units. The test checks whether the name of the curriculum exist in the view and the same with the learning unit name.