### PR TITLE
feat: extend the functionality of curriculums controller to many curriculums

### DIFF
--- a/app/controllers/curriculums_controller.rb
+++ b/app/controllers/curriculums_controller.rb
@@ -1,5 +1,14 @@
 class CurriculumsController < ApplicationController
+  before_action :set_curriculum
   def show
-    redirect_to curriculum_learning_units_path(Curriculum.first)
+    redirect_to curriculum_learning_units_path(@curriculum)
+  end
+
+  def set_curriculum
+    @curriculum = if params[:id].present?
+                    Curriculum.find(params[:id])
+                  else
+                    Curriculum.first
+                  end
   end
 end

--- a/spec/requests/curriculums_controller_spec.rb
+++ b/spec/requests/curriculums_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe CurriculumsController, type: :request do
+  describe 'GET /show' do
+    let(:user) { create(:user) }
+    let(:curriculum) { curriculum_with_learning_units }
+    let(:learning_unit) { create(:learning_unit) }
+
+    before do
+      sign_in user
+    end
+
+    context 'when accesing the curriculum show page' do
+      def perform
+        get curriculum_path(curriculum)
+      end
+
+      it 'redirects to the learning units index page' do
+        perform
+        expect(perform).to redirect_to(curriculum_learning_units_path(curriculum))
+      end
+    end
+  end
+end


### PR DESCRIPTION
At first the curriculums controller assumed that there was only one curriculum. I modified the curriculums controller to work with any number of curriculums.  The actual behavior of the show method is redirect to the index view of the curriculum's learning units.

Additionally, I created the corresponding request test for the curriculums controller.