### PR TITLE
chore: removed pry gem. Unnecessary in rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,6 @@ end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem 'pry-rails'
 
   gem 'web-console'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,6 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
-    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     debug (1.6.2)
@@ -202,11 +201,6 @@ GEM
     parser (3.1.2.1)
       ast (~> 2.4.1)
     pg (1.4.3)
-    pry (0.14.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -368,7 +362,6 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   pg (~> 1.1)
-  pry-rails
   puma (~> 5.0)
   rails (~> 7.0.3, >= 7.0.3.1)
   rails-controller-testing


### PR DESCRIPTION
You can use binding.break to get the same outcome.
The gem also changes the rails console to a worse one.